### PR TITLE
[zabbix-5.x] 🔨 Patch import error on Zabbix 5.2

### DIFF
--- a/zabbix5.0/zbx_edgemax_template.xml
+++ b/zabbix5.0/zbx_edgemax_template.xml
@@ -13,7 +13,7 @@
             <name>Template EdgeMAX SNMPv2</name>
             <templates>
                 <template>
-                    <name>Template Net Network Generic Device SNMP</name>
+                    <name>Template Net Network Generic Device SNMPv2</name>
                 </template>
             </templates>
             <groups>


### PR DESCRIPTION
Resolves #6 by adjusting the linked template name that was changed in newer Zabbix versions.